### PR TITLE
Pass the devtools::test

### DIFF
--- a/tests/testthat/test-examplemodule.R
+++ b/tests/testthat/test-examplemodule.R
@@ -1,7 +1,7 @@
 context("exampleModuleServer")
 
 # See ?testServer for more information
-testServer(exampleModuleServer, {
+shiny::testServer(exampleModuleServer, {
   # Set initial value of a button
   session$setInputs(button = 0)
 

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -1,6 +1,6 @@
 context("app")
 
-testServer(expr = {
+shiny::testServer(expr = {
   # Set the `size` slider and check the output
   session$setInputs(size = 6)
   expect_equal(output$sequence, "1 2 3 4 5 6")


### PR DESCRIPTION
I could understand that passing the `devtools::check` is not the objective, although `devtools::test` should obviously working. We need to use `shiny::` for `testServer`  or `library(shiny)` in the testthat dir, I prefer the first solution. This update should be applied to the rest 2 branches too.

Now the `devtools::test` is passing.

Ps. Passing `devtools::check` should be considered in my opinion, not sure if it is a trivial one under the current design. There seems to be a problem with `findEnclosingApp(".")`.
